### PR TITLE
national manager set by default

### DIFF
--- a/contact_modification/models/res_partner.py
+++ b/contact_modification/models/res_partner.py
@@ -211,22 +211,21 @@ class Partner(models.Model):
         """
         if vals.get("national_user_id", False):
             new_national_mgr = vals["national_user_id"]
+            subsidiary_companies = {}
 
             if self.company_type == "management" and self.mangement_company_type != "greystar":
                 subsidiary_companies = self.env["res.partner"].search([("management_company_type_id", "=", self.id)])
 
-                for company in subsidiary_companies:
-                    company.write({"national_user_id": new_national_mgr})
             elif self.id == 29824:  # Master Greystar Entity
                 greystar_regional_mgmt_companies = self.env["res.partner"].search(
                     [("mangement_company_type", "=", "greystar")]
                 )
-                greystar_subsidiary_companies = self.env["res.partner"].search(
+                subsidiary_companies = self.env["res.partner"].search(
                     [("management_company_type_id", "in", greystar_regional_mgmt_companies.ids)]
                 )
 
-                for company in greystar_subsidiary_companies:
-                    company.write({"national_user_id": new_national_mgr})
+            for company in subsidiary_companies:
+                company.write({"national_user_id": new_national_mgr})
 
         # Update non-user contact in CLXDB
         if not self.user_ids.id:

--- a/contact_modification/models/res_partner.py
+++ b/contact_modification/models/res_partner.py
@@ -204,6 +204,11 @@ class Partner(models.Model):
     def write(self, vals):
         res = super(Partner, self).write(vals)
 
+        """
+        If the national account manager is changed at the manamement company
+        level, then update the national manager on all it's childeren. Greystar
+        is currently a special use case because it have a master management company
+        """
         if vals.get("national_user_id", False):
             new_national_mgr = vals["national_user_id"]
 

--- a/contact_modification/views/res_partner_view.xml
+++ b/contact_modification/views/res_partner_view.xml
@@ -327,14 +327,14 @@
             </xpath>
 
             <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']" position="after">
+                <field name="national_mgr_hidden" invisible="1"/>
                 <field name="implementation_specialist_id" attrs="{'invisible':[('company_type','not in','company')]}"/>
                 <field name="account_user_id" 
                        attrs="{'invisible':['|','|','|',('is_company','=',False),('is_management','=',True),('is_owner','=',True),('is_vendor','=',True)],
                                'required':[('is_company','=',True)]}"/>
                 <field name="secondary_user_id"
                        attrs="{'invisible':['|','|',('is_company','=',False),('is_management','=',True),('is_owner','=',True)]}"/>
-                <field name="national_user_id"
-                       attrs="{'invisible':['|','|',('is_company','=',False),('is_management','=',True),('is_owner','=',True)]}"/>
+                <field name="national_user_id" attrs="{'invisible':[('national_mgr_hidden','=',True)]}"/>
             </xpath>
 
             <xpath expr="//notebook//page[1]//field[@name='child_ids']" position="attributes">


### PR DESCRIPTION
# JIRA
[CLXD-1308](https://clxmedia.atlassian.net/browse/CLXD-1308)
Merging directly to QA because my dev branch is currently blocked.

# Description

- expose national manager field on management contact. Field is now used on company and management contact types
- update all subsidiary company's national manager if change at the management level
- special use case to deal with Greystar where there is a master management company
- auto set national manager at company level when selecting an management company during create or edit  
