### PR TITLE
Made the lead_vertical required a conditional attribute

### DIFF
--- a/clx_crm/views/crm_lead_views.xml
+++ b/clx_crm/views/crm_lead_views.xml
@@ -133,7 +133,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='website']" position="after">
-                    <field name="lead_vertical" required="True"/>
+                <field name="lead_vertical" attrs="{'required': [('type','=', 'lead')]}" />
             </xpath>
             <xpath expr="//page[@name='extra']" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
# JIRA

https://clxmedia.atlassian.net/browse/CLXD-1567

# Description

When converting a lead to an opportunity, if the user edited the information and tried to save, they received an error that the "Vertical" field was invalid. The field was not present for editing in the UI, causing the error. 

The issue was that this view was shared by the lead creation view where the field was visible. Odoo has unique patterns where fields are made invisible, required, etc based on the type of data being used. 

This PR makes the lead_vertical field conditionally required if the type is a "lead" vs anything else (e.g. "opportunity").
